### PR TITLE
feat: 글로벌 예외 처리 적용 및 CustomException 구조 도입

### DIFF
--- a/src/main/java/com/neutral/newspaper/global/CustomException.java
+++ b/src/main/java/com/neutral/newspaper/global/CustomException.java
@@ -1,0 +1,13 @@
+package com.neutral.newspaper.global;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorType errorType;
+
+    public CustomException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+}

--- a/src/main/java/com/neutral/newspaper/global/ErrorResponse.java
+++ b/src/main/java/com/neutral/newspaper/global/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.neutral.newspaper.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private int code;
+    private String message;
+}

--- a/src/main/java/com/neutral/newspaper/global/ErrorType.java
+++ b/src/main/java/com/neutral/newspaper/global/ErrorType.java
@@ -1,0 +1,24 @@
+package com.neutral.newspaper.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorType {
+    DUPLICATED_EMAIL(1000, "이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
+    INVALID_PASSWORD_FORMAT(1001, "비밀번호는 8~16자의 영어, 숫자, 특수기호(@$!%*?&)를 포함해야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PHONE_NUMBER_FORMAT(1002, "휴대폰 번호는 10~11자여야 합니다.", HttpStatus.BAD_REQUEST),
+    NOT_REGISTERED_MEMBER(1003, "존재하지 않는 회원입니다.", HttpStatus.UNAUTHORIZED),
+    MEMBER_NOT_FOUND(1004, "회원 정보를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_MATCHED_PASSWORD(1005, "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_MATCHED_PHONE_NUMBER(1006, "휴대폰 번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_MATCHED_VERIFYING_CODE(1007, "인증번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    UNAUTHORIZED_VERIFICATION(1008, "인증이 완료되지 않았습니다.", HttpStatus.UNAUTHORIZED),
+    ;
+
+    private final int code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/neutral/newspaper/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/neutral/newspaper/global/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.neutral.newspaper.global;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,9 +9,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
-        log.error("잘못된 요청: {}", exception.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException exception) {
+        log.error("CustomException: {}", exception.getMessage());
+        ErrorType errorType = exception.getErrorType();
+        ErrorResponse response = new ErrorResponse(errorType.getCode(), errorType.getMessage());
+        return ResponseEntity.status(errorType.getHttpStatus()).body(response);
     }
 }

--- a/src/main/java/com/neutral/newspaper/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/neutral/newspaper/global/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.neutral.newspaper.global;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
+        log.error("잘못된 요청: {}", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- GlobalExceptionHandler를 추가하여 전역에서 발생하는 예외를 통합적으로 처리할 수 있도록 구성
- CustomException 및 ErrorType enum을 도입해 각 도메인별 예외 정보를 명확히 구분
- ErrorResponse 클래스를 추가하여 클라이언트에게 일관된 형식의 에러 메시지 제공
- 회원가입 시 발생할 수 있는 예외에 대해 ErrorType 기반 처리 적용 (예: 이메일 중복, 비밀번호 형식 오류 등)

## 📌 적용 범위
- 테스트 코드에서 발생한 에러에 대응하기 위해 상태 코드 재설정 (`BAD_REQUEST`, `CONFLICT` 등)

## 🚨 주의 사항
- 기존의 `IllegalArgumentException`에 의존하던 부분을 CustomException으로 전환했기 때문에 전반적인 예외 처리 구조가 바뀜
- 추가적인 예외 상황들도 ErrorType 기반으로 확장 필요

## ✅ 관련 이슈
- 회원가입 실패 케이스 테스트 작성 중 예외 핸들링 개선 필요성 발견