### PR TITLE
test: MemberController API 성공 케이스 테스트 작성

### DIFF
--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.neutral.newspaper.member;
 
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -12,6 +13,7 @@ import com.neutral.newspaper.jwt.JwtToken;
 import com.neutral.newspaper.member.controller.MemberController;
 import com.neutral.newspaper.member.dto.JoinRequestDto;
 import com.neutral.newspaper.member.dto.LoginRequestDto;
+import com.neutral.newspaper.member.dto.UpdatePasswordDto;
 import com.neutral.newspaper.member.service.MemberService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -57,14 +59,28 @@ public class MemberControllerTest {
     @WithMockUser
     @Test
     @DisplayName("로그인 성공 시 200 반환")
-    void loginSuccess() throws Exception {
-        LoginRequestDto dto = new LoginRequestDto("email@example.com", "TestPassword12!");
+    void successLogin() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("email@example.com", "TestPassword12!");
         when(memberService.login(any())).thenReturn(new JwtToken("Bearer", "access-token", "refresh-token"));
 
         mockMvc.perform(post("/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto))
+                        .content(objectMapper.writeValueAsString(loginRequest))
                         .with(csrf()))
                 .andExpect(status().isOk());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("비밀번호 변경 성공 시 204 반환")
+    void successChangingPassword() throws Exception {
+        UpdatePasswordDto updatePassword = new UpdatePasswordDto("email@example.com", "TestPassword12!");
+        doNothing().when(memberService).updatePassword(any());
+
+        mockMvc.perform(post("/member/update-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatePassword))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -14,6 +14,7 @@ import com.neutral.newspaper.member.controller.MemberController;
 import com.neutral.newspaper.member.dto.FindPasswordDto;
 import com.neutral.newspaper.member.dto.JoinRequestDto;
 import com.neutral.newspaper.member.dto.LoginRequestDto;
+import com.neutral.newspaper.member.dto.ResetPasswordDto;
 import com.neutral.newspaper.member.dto.UpdatePasswordDto;
 import com.neutral.newspaper.member.dto.VerifyCodeDto;
 import com.neutral.newspaper.member.service.MemberService;
@@ -110,6 +111,20 @@ public class MemberControllerTest {
         mockMvc.perform(post("/member/verify-code")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(verifyCodeRequest))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("비밀번호 초기화 성공 시 204 반환")
+    void successResetCode() throws Exception {
+        ResetPasswordDto resetPasswordRequest = new ResetPasswordDto("email@example.com", "NewPassword12!");
+        doNothing().when(memberService).resetPassword(any());
+
+        mockMvc.perform(post("/member/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(resetPasswordRequest))
                         .with(csrf()))
                 .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -1,0 +1,107 @@
+package com.neutral.newspaper.member;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neutral.newspaper.global.CustomException;
+import com.neutral.newspaper.global.ErrorType;
+import com.neutral.newspaper.member.controller.MemberController;
+import com.neutral.newspaper.member.dto.JoinRequestDto;
+import com.neutral.newspaper.member.service.MemberService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc
+public class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @WithMockUser
+    @Test
+    @DisplayName("회원가입 성공")
+    void successSignUp() throws Exception {
+        JoinRequestDto joinRequest = new JoinRequestDto(
+                "홍길동", "email@example.com", "TestPassword12!", "010-1234-5678", List.of("경제", "스포츠")
+        );
+
+        when(memberService.registerMember(any(JoinRequestDto.class))).thenReturn("회원가입이 완료되었습니다.");
+
+        mockMvc.perform(post("/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    void failSignUpDuplicatedEmail() throws Exception {
+        JoinRequestDto joinRequest = new JoinRequestDto(
+                "홍길동", "email@example.com", "TestPassword12!", "010-1234-5678", List.of("경제", "스포츠")
+        );
+
+        when(memberService.registerMember(any(JoinRequestDto.class))).thenThrow(new CustomException(ErrorType.DUPLICATED_EMAIL));
+
+        mockMvc.perform(post("/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest))
+                        .with(csrf()))
+                .andExpect(status().isConflict());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("회원가입 실패 - 비밀번호 형식 오류")
+    void failSignUpInvalidPassword() throws Exception {
+        JoinRequestDto joinRequest = new JoinRequestDto(
+                "홍길동", "email@example.com", "test", "010-1234-5678", List.of("경제", "스포츠")
+        );
+
+        when(memberService.registerMember(any(JoinRequestDto.class))).thenThrow(new CustomException(ErrorType.INVALID_PASSWORD_FORMAT));
+
+        mockMvc.perform(post("/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("회원가입 실패 - 휴대전화 번호 형식 오류")
+    void failSignUpInvalidPhoneNumber() throws Exception {
+        JoinRequestDto joinRequest = new JoinRequestDto(
+                "홍길동", "email@example.com", "TestPassword12!", "010-1234-56789", List.of("경제", "스포츠")
+        );
+
+        when(memberService.registerMember(any(JoinRequestDto.class))).thenThrow(new CustomException(ErrorType.INVALID_PHONE_NUMBER_FORMAT));
+
+        mockMvc.perform(post("/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neutral.newspaper.jwt.JwtToken;
 import com.neutral.newspaper.member.controller.MemberController;
+import com.neutral.newspaper.member.dto.FindPasswordDto;
 import com.neutral.newspaper.member.dto.JoinRequestDto;
 import com.neutral.newspaper.member.dto.LoginRequestDto;
 import com.neutral.newspaper.member.dto.UpdatePasswordDto;
@@ -80,6 +81,20 @@ public class MemberControllerTest {
         mockMvc.perform(post("/member/update-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updatePassword))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("비밀번호 초기화 코드 전송 성공 시 204 반환")
+    void successSendingPasswordResetCode() throws Exception {
+        FindPasswordDto findPasswordRequest = new FindPasswordDto("email@example.com", "010-1234-5678");
+        doNothing().when(memberService).sendPasswordResetCode(any());
+
+        mockMvc.perform(post("/member/send-password-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(findPasswordRequest))
                         .with(csrf()))
                 .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -10,12 +10,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neutral.newspaper.global.CustomException;
 import com.neutral.newspaper.global.ErrorType;
+import com.neutral.newspaper.jwt.JwtToken;
 import com.neutral.newspaper.member.controller.MemberController;
 import com.neutral.newspaper.member.dto.JoinRequestDto;
+import com.neutral.newspaper.member.dto.LoginRequestDto;
 import com.neutral.newspaper.member.service.MemberService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -39,7 +42,7 @@ public class MemberControllerTest {
 
     @WithMockUser
     @Test
-    @DisplayName("회원가입 성공")
+    @DisplayName("회원가입 요청 성공 시 200 반환")
     void successSignUp() throws Exception {
         JoinRequestDto joinRequest = new JoinRequestDto(
                 "홍길동", "email@example.com", "TestPassword12!", "010-1234-5678", List.of("경제", "스포츠")
@@ -52,56 +55,5 @@ public class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(joinRequest))
                         .with(csrf()))
                 .andExpect(status().isOk());
-    }
-
-    @WithMockUser
-    @Test
-    @DisplayName("회원가입 실패 - 이메일 중복")
-    void failSignUpDuplicatedEmail() throws Exception {
-        JoinRequestDto joinRequest = new JoinRequestDto(
-                "홍길동", "email@example.com", "TestPassword12!", "010-1234-5678", List.of("경제", "스포츠")
-        );
-
-        when(memberService.registerMember(any(JoinRequestDto.class))).thenThrow(new CustomException(ErrorType.DUPLICATED_EMAIL));
-
-        mockMvc.perform(post("/member/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(joinRequest))
-                        .with(csrf()))
-                .andExpect(status().isConflict());
-    }
-
-    @WithMockUser
-    @Test
-    @DisplayName("회원가입 실패 - 비밀번호 형식 오류")
-    void failSignUpInvalidPassword() throws Exception {
-        JoinRequestDto joinRequest = new JoinRequestDto(
-                "홍길동", "email@example.com", "test", "010-1234-5678", List.of("경제", "스포츠")
-        );
-
-        when(memberService.registerMember(any(JoinRequestDto.class))).thenThrow(new CustomException(ErrorType.INVALID_PASSWORD_FORMAT));
-
-        mockMvc.perform(post("/member/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(joinRequest))
-                        .with(csrf()))
-                .andExpect(status().isBadRequest());
-    }
-
-    @WithMockUser
-    @Test
-    @DisplayName("회원가입 실패 - 휴대전화 번호 형식 오류")
-    void failSignUpInvalidPhoneNumber() throws Exception {
-        JoinRequestDto joinRequest = new JoinRequestDto(
-                "홍길동", "email@example.com", "TestPassword12!", "010-1234-56789", List.of("경제", "스포츠")
-        );
-
-        when(memberService.registerMember(any(JoinRequestDto.class))).thenThrow(new CustomException(ErrorType.INVALID_PHONE_NUMBER_FORMAT));
-
-        mockMvc.perform(post("/member/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(joinRequest))
-                        .with(csrf()))
-                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -8,8 +8,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.neutral.newspaper.global.CustomException;
-import com.neutral.newspaper.global.ErrorType;
 import com.neutral.newspaper.jwt.JwtToken;
 import com.neutral.newspaper.member.controller.MemberController;
 import com.neutral.newspaper.member.dto.JoinRequestDto;
@@ -18,7 +16,6 @@ import com.neutral.newspaper.member.service.MemberService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -53,6 +50,20 @@ public class MemberControllerTest {
         mockMvc.perform(post("/member/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(joinRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("로그인 성공 시 200 반환")
+    void loginSuccess() throws Exception {
+        LoginRequestDto dto = new LoginRequestDto("email@example.com", "TestPassword12!");
+        when(memberService.login(any())).thenReturn(new JwtToken("Bearer", "access-token", "refresh-token"));
+
+        mockMvc.perform(post("/member/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto))
                         .with(csrf()))
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/member/MemberControllerTest.java
@@ -15,6 +15,7 @@ import com.neutral.newspaper.member.dto.FindPasswordDto;
 import com.neutral.newspaper.member.dto.JoinRequestDto;
 import com.neutral.newspaper.member.dto.LoginRequestDto;
 import com.neutral.newspaper.member.dto.UpdatePasswordDto;
+import com.neutral.newspaper.member.dto.VerifyCodeDto;
 import com.neutral.newspaper.member.service.MemberService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -95,6 +96,20 @@ public class MemberControllerTest {
         mockMvc.perform(post("/member/send-password-code")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(findPasswordRequest))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("비밀번호 초기화 코드 인증 성공 시 204 반환")
+    void successVerifyingCode() throws Exception {
+        VerifyCodeDto verifyCodeRequest = new VerifyCodeDto("email@example.com", "123456");
+        doNothing().when(memberService).verifyCode(any());
+
+        mockMvc.perform(post("/member/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(verifyCodeRequest))
                         .with(csrf()))
                 .andExpect(status().isNoContent());
     }


### PR DESCRIPTION
## ✨ 작업 내용
- MemberController에 대한 성공 케이스 테스트 코드 작성
  - 회원가입 (/member/signup)
  - 로그인 (/member/login)
  - 비밀번호 변경 (/member/update-password)
  - 비밀번호 초기화 요청 (/member/send-password-code)
  - 인증 코드 검증 (/member/verify-code)
  - 비밀번호 초기화 (/member/reset-password)

## 📌 적용 범위
- MemberControllerTest 클래스 생성 및 주요 API의 정상 흐름 테스트 구현
- MockMvc 기반 HTTP 요청 시나리오 검증

## 🚨 주의 사항
- MemberService는 Mock 객체로 대체

## ✅ 관련 이슈
- 컨트롤러 계층의 API 응답 흐름을 검증할 수 있는 테스트 기반 마련 필요성 → MockMvc 기반 컨트롤러 테스트 도입
