### PR TITLE
test: MapService 및 MapController 성공 케이스 테스트 추가

### DIFF
--- a/src/test/java/com/neutral/newspaper/news/map/MapControllerTest.java
+++ b/src/test/java/com/neutral/newspaper/news/map/MapControllerTest.java
@@ -1,0 +1,60 @@
+package com.neutral.newspaper.news.map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neutral.newspaper.news.map.controller.MapController;
+import com.neutral.newspaper.news.map.domain.NewsInfoDto;
+import com.neutral.newspaper.news.map.domain.SearchRegionNewsResponseDto;
+import com.neutral.newspaper.news.map.service.MapService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MapController.class)
+public class MapControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MapService mapService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @WithMockUser
+    @Test
+    @DisplayName("지역 뉴스 검색 성공 시 200 반환")
+    void successGettingRegionNews() throws Exception {
+        // given
+        NewsInfoDto newsInfo = new NewsInfoDto(
+                "축제 뉴스 제목", "http://examplenews.com", "축제 뉴스 설명"
+        );
+
+        SearchRegionNewsResponseDto response = new SearchRegionNewsResponseDto(
+                "서울", "축제", List.of(newsInfo)
+        );
+
+        when(mapService.findRegionNews(anyString(), anyString())).thenReturn(response);
+
+        // when, then
+        mockMvc.perform(post("/map")
+                        .param("region", "서울")
+                        .param("category", "축제")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/neutral/newspaper/news/map/MapServiceTest.java
+++ b/src/test/java/com/neutral/newspaper/news/map/MapServiceTest.java
@@ -1,0 +1,52 @@
+package com.neutral.newspaper.news.map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.neutral.newspaper.news.map.domain.NewsInfoDto;
+import com.neutral.newspaper.news.map.domain.SearchRegionNewsResponseDto;
+import com.neutral.newspaper.news.map.service.MapService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+public class MapServiceTest {
+
+    @InjectMocks
+    private MapService mapService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Test
+    @DisplayName("지역 뉴스 검색 성공 케이스")
+    void successFindingRegionNews() {
+        // given
+        NewsInfoDto newsInfo = new NewsInfoDto(
+                "축제 뉴스 제목", "http://examplenews.com", "축제 뉴스 내용"
+        );
+
+        SearchRegionNewsResponseDto response = new SearchRegionNewsResponseDto(
+                "서울", "축제", List.of(newsInfo)
+        );
+
+        when(restTemplate.getForEntity(
+                anyString(), eq(SearchRegionNewsResponseDto.class), anyString(), anyString()
+        )).thenReturn(ResponseEntity.ok(response));
+
+        // when
+        SearchRegionNewsResponseDto result = mapService.findRegionNews("서울", "경제");
+
+        // then
+        assertThat(result).isNotNull();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- MapService에 대한 성공 케이스 테스트 코드 작성
- MapController에 대한 성공 케이스 테스트 코드 작성
  - 지역 뉴스 검색 (/map)

## 📌 적용 범위
- MapServiceTest 클래스 생성 및 지역 뉴스 검색 서비스 로직 테스트
- MapControllerTest 클래스 생성 및 API 정상 흐름 테스트
- MockMvc 기반 HTTP 요청 시나리오 검증

## 🚨 주의 사항
- MapService, MapController 모두 Mock 객체 기반 테스트 진행

## ✅ 관련 이슈
- 지역 기반 뉴스 검색 서비스 및 컨트롤러 정상 동작 검증을 위한 테스트 기반 마련 필요성 → 단위 테스트 + 컨트롤러 테스트 동시 도입